### PR TITLE
Enable run-script use

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ dependency scanning:
     reports:
       dependency_scanning: gl-dependency-scanning.json
 ```
-NOTE: If you use a `npm run-script` to call `npm audit` You must add the option `--silent` to `npm run` or have `.npmrc` set the NPM loglevel to silent otherwise the shell output will conflict with the stdin piping to this parser and cause an error.
+NOTE: If you use a `npm run-script` to call `npm audit` due to set project parameters,
+this library will ignore any prefixed stdout data prior to the first open bracket for
+the JSON output. This way `npm run --silent` is no longer required.
 
 ## Test
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -1,8 +1,25 @@
 var capitalize = require("./utils").capitalize;
 var getCWEId = require("./utils").getCWEId;
 
-var convert = function (json) {
-    return JSON.stringify(convertReportForType(JSON.parse(json)), null, "  ");
+var convert = function (data) {
+    var json = data;
+    if (!/^\s*{/.test(data)) {
+      // Trim any leading npm loglevel information
+      json = data.replace(/^([^{])*{/, "{")
+    }
+    try {
+      json = JSON.parse(json); // internally runs trim()
+    } catch (error) {
+      if (Object.getPrototypeOf(error) === SyntaxError.prototype) {
+        throw new Error("Data provided is not JSON parsable. Check input format.");
+      }
+      throw error;
+    }
+    try {
+      return JSON.stringify(convertReportForType(json), null, "  ");
+    } catch (error) {
+      throw new Error(`Internal error!\n Caused by:\n ${error.toString()}`);
+    }
 };
 
 function convertReportForType(parsedData) {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "test": "test"
   },
   "scripts": {
-    "test": "npm run test:v1 && npm run test:v2",
+    "test": "npm run test:v1 && npm run test:v2 && npm run test:run-script-use",
     "test:v1": "cat test/v1_report.json | ./parse.js -o GL-report.1.json && diff -q GL-report.1.json test/snapshot/GL-report.1.json && echo success!; rm GL-report.1.json",
-    "test:v2": "cat test/v2_report.json | ./parse.js -o GL-report.2.json && diff -q GL-report.2.json test/snapshot/GL-report.2.json && echo success!; rm GL-report.2.json"
+    "test:v2": "cat test/v2_report.json | ./parse.js -o GL-report.2.json && diff -q GL-report.2.json test/snapshot/GL-report.2.json && echo success!; rm GL-report.2.json",
+    "test:run-script-use": "bash -c 'cat <(echo -e \"\n> npm audit --json\n\") test/v2_report.json' | ./parse.js -o GL-report.runs.json && diff -q GL-report.runs.json test/snapshot/GL-report.2.json && echo success!; rm GL-report.runs.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "test": "test"
   },
   "scripts": {
-    "test": "npm run test:v1 && npm run test:v2 && npm run test:run-script-use",
-    "test:v1": "cat test/v1_report.json | ./parse.js -o GL-report.1.json && diff -q GL-report.1.json test/snapshot/GL-report.1.json && echo success!; rm GL-report.1.json",
-    "test:v2": "cat test/v2_report.json | ./parse.js -o GL-report.2.json && diff -q GL-report.2.json test/snapshot/GL-report.2.json && echo success!; rm GL-report.2.json",
-    "test:run-script-use": "bash -c 'cat <(echo -e \"\n> npm audit --json\n\") test/v2_report.json' | ./parse.js -o GL-report.runs.json && diff -q GL-report.runs.json test/snapshot/GL-report.2.json && echo success!; rm GL-report.runs.json"
+    "test": "npm run --silent test:v1; npm run --silent test:v2; npm run --silent test:run-script-use;",
+    "test:v1": "printf 'v1: '; cat test/v1_report.json | ./parse.js -o GL-report.1.json >/dev/null && diff -q GL-report.1.json test/snapshot/GL-report.1.json && echo success!; RC=$?; rm GL-report.1.json; exit $RC",
+    "test:v2": "printf 'v2: '; cat test/v2_report.json | ./parse.js -o GL-report.2.json >/dev/null && diff -q GL-report.2.json test/snapshot/GL-report.2.json && echo success!; RC=$?; rm GL-report.2.json; exit $RC",
+    "test:run-script-use": "printf 'run-script-use: '; bash -c 'cat <(echo -e \"\n> npm audit --json\n\") test/v2_report.json' | ./parse.js -o GL-report.runs.json >/dev/null && diff -q GL-report.runs.json test/snapshot/GL-report.2.json && echo success!; RC=$?; rm GL-report.runs.json; exit $RC"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Purpose

When setting a configuration in the npm run-scripts for `npm audit` usage (such as the acceptable audit level) and npm is not silent, it causes the library to fail.  This occurs since npm by default prints out what run-script it is executing and when npm is not silent this stdout statement is included in the output that is piped to this parser and it fails hard. 

I added a test script that exemplifies this scenario.

### FIX
In order to enable run-script usage without users requiring the`--silent` parameter, this code will clear any prefixed information up until the first open bracket indicating the start of JSON output.  

Additionally, I also added some error handling to help with clarity when the input fails to parse.

### How To Verify
```sh
# 1. Add my remote repo & Checkout this branch
$ git remote add codejedi365 https://github.com/codejedi365/gitlab-npm-audit-parser.git
$ git fetch codejedi365
$ git checkout --track codejedi365 codejedi365-enable-run-script-use

# 2. Install Dependencies from scratch
$ npm ci

# 3. Revert & Replicate error through test case (3rd test case fails)
$ git reset --hard HEAD~1 && npm test

# 4. Reapply fix action and verify test now succeeds
$ git pull --ff-only && npm test

# cleanup
$ git remote remove codejedi365
```

**Note: This has merge conflicts with #3 due to run-script modifications. Depending if this PR is desired to be accepted, will adjust the other PR to match.**
